### PR TITLE
fix: no colored output with concurrency!=1

### DIFF
--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -62,7 +62,7 @@ func (l *logAggregatorImpl) GetWriter(ctx context.Context) (io.Writer, func(), e
 
 	writer := io.Writer(w)
 	if output.IsColorable(l.out) {
-		writer = output.GetWriter(ctx, writer, output.DefaultColorCode, false, false)
+		writer = output.GetWriter(ctx, writer, output.DefaultColorCode, true, false)
 	}
 	ch := make(chan string, buffSize)
 	l.messages <- ch


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6521<!-- tracking issues that this PR will close -->

**Description**
lose all colors even for deployers, loggers and port-forward messages if the artifacts are built with concurrency != 1. 
support colored output with concurrency!=1.

**Changes**

**before**
when concurrency != 1,  color is disabled in skaffoldWriter
if concurrency=0, `io.Writer` is `os.pipe` type, so `isTerm` always return false


```
// SetupColors conditionally wraps the input `Writer` with a color enabled `Writer`
func SetupColors(ctx context.Context, out io.Writer, defaultColor int, forceColors bool) io.Writer {

	_, isTerm := term.IsTerminal(out)
	supportsColor, err := term.SupportsColor(ctx)

	if err != nil {
		log.Entry(context.TODO()).Debugf("error checking for color support: %v", err)
	}

	useColors := (isTerm && supportsColor) || forceColors
	if useColors {
		// Use EnableColorsStdout to enable use of color on Windows
		useColors = false // value is updated if color-enablement is successful
		colorable.EnableColorsStdout(&useColors)
	}

	colors.Disable(!useColors)
	......
        ......
}
```

**after**

i I passed the `forceColors` parameter as true in the function of  `(l *logAggregatorImpl)getWriter `, `(isTerm && supportsColor) || forceColors` always return true 


